### PR TITLE
Better device name deletion method

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -171,7 +171,11 @@ jobs:
                 echo "Device ${dev} is not supported"
               else
                 echo "Device ${dev} is already supported"
-                MISSINGS=(${MISSINGS[@]/${dev}})
+                for i in "${!MISSINGS[@]}""; do
+                  if [[ ${MISSINGS[i]} = ${dev} ]]; then
+                    unset 'MISSINGS[i]'
+                  fi
+                done
               fi
             done
             if [ 0 -ne ${#MISSINGS[@]} ]; then


### PR DESCRIPTION
The method used for deletion of found devices cause error in the missing list creation for L1 family.
This is due to the fact in this family some device exist in -A, -X or without extention.

Deleting devices that from pattern STM32L1XX let remain -A STM32L1XX-A and -X for STM32L1XX-X so the list of unsupported is not usable.